### PR TITLE
Remove 443 binding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ FROM lancachenet/ubuntu:latest
 MAINTAINER LanCache.Net Team <team@lancache.net>
 ARG DEBIAN_FRONTEND=noninteractive
 COPY overlay/ /
-ENV SSL_KEY=/ssl/ssl.key \
-    SSL_CERT=/ssl/ssl.crt \
-    DOCUMENT_ROOT=html
+ENV DOCUMENT_ROOT=html
 RUN apt-get update && apt-get install -y nginx inotify-tools
 RUN \
     chmod 777 /opt/nginx/startnginx.sh && \
@@ -21,4 +19,4 @@ RUN \
     chmod 755 /var/www && \
     chmod -R 666 /etc/nginx/sites-* /etc/nginx/conf.d/*
 
-EXPOSE 80 443
+EXPOSE 80


### PR DESCRIPTION
443 is not currently used in lancache.net so we should remove it