### PR TITLE
Adding --no-install-recommends to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM lancachenet/ubuntu:latest
 MAINTAINER LanCache.Net Team <team@lancache.net>
 ARG DEBIAN_FRONTEND=noninteractive
 COPY overlay/ /
-RUN apt-get update && apt-get install -y nginx-full inotify-tools
+RUN apt-get update && \
+    apt-get install -y nginx-full inotify-tools --no-install-recommends && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
 RUN \
     chmod 777 /opt/nginx/startnginx.sh && \
     rm /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default && \


### PR DESCRIPTION
Adding `--no-install-recommends` drops the resulting image size by about40 megabytes. See screenshot:

![image](https://github.com/lancachenet/ubuntu-nginx/assets/766513/a8252ba8-b2b5-41a7-bed8-f82c2dbe955d)
